### PR TITLE
Build up result in array instead of strings

### DIFF
--- a/src/esrever.js
+++ b/src/esrever.js
@@ -32,12 +32,12 @@
 			// Swap high and low surrogates so the low surrogates go first
 			.replace(regexSurrogatePair, '$2$1');
 		// Step 2: reverse the code units in the string
-		var result = '';
+		var result = [];
 		var index = string.length;
 		while (index--) {
-			result += string.charAt(index);
+			result.push(string.charAt(index));
 		}
-		return result;
+		return result.join('');
 	};
 
 	/*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Incrementally concatenating strings means a lot of intermediate
strings get allocated only to be thrown away. The result is `O(n**2)`
in both space and time.

See this post about Shlemiel the painter's algorithm for a good
description about the quadratic behavior involved.

https://www.joelonsoftware.com/2001/12/11/back-to-basics/

Storing each fragment in an array and joining them all together
in the end at least avoids allocating ever-longer intermediate
strings. I have not run any benchmarks on very long strings,
though. That might still be interesting to do.