### PR TITLE
Fixes zero-width joiner issue

### DIFF
--- a/esrever.js
+++ b/esrever.js
@@ -30,14 +30,16 @@
 				return reverse($2) + $1;
 			})
 			// Swap high and low surrogates so the low surrogates go first
-			.replace(regexSurrogatePair, '$2$1');
+			.replace(regexSurrogatePair, '$2$1')
+			.replace(/(..)(\u200d)(..)(\u200d)(..)/g, '$5$4$3$2$1')
+			.replace(/(?<!\u200d)(..)(\u200d)(..)(?!\u200d)/g, '$3$2$1');
 		// Step 2: reverse the code units in the string
-		var result = '';
+		var result = [];
 		var index = string.length;
 		while (index--) {
-			result += string.charAt(index);
+			result.push(string.charAt(index));
 		}
-		return result;
+		return result.join('');
 	};
 
 	/*--------------------------------------------------------------------------*/

--- a/src/esrever.js
+++ b/src/esrever.js
@@ -30,7 +30,9 @@
 				return reverse($2) + $1;
 			})
 			// Swap high and low surrogates so the low surrogates go first
-			.replace(regexSurrogatePair, '$2$1');
+			.replace(regexSurrogatePair, '$2$1')
+			.replace(/(..)(\u200d)(..)(\u200d)(..)/g, '$5$4$3$2$1')
+			.replace(/(?<!\u200d)(..)(\u200d)(..)(?!\u200d)/g, '$3$2$1');
 		// Step 2: reverse the code units in the string
 		var result = [];
 		var index = string.length;


### PR DESCRIPTION
There is a problem when `esrever.reverse('👨‍💻')` will result in `'💻‍👨'`. [link](https://mothereff.in/reverse-string#%F0%9F%91%A8%E2%80%8D%F0%9F%92%BB)

This happens because the script doesn't do anything about zero-width joiners (`\u200d`).

Suggested solution is not elegant and works only when there are one or two zero-width joiners. I'm not sure if there are symbols with more than two. I guess it's sufficient.

I also run `grunt` cli command. That is the reason for other changes in `esrever.js`.